### PR TITLE
:book: Use the same style for ToC entry to roadmap as in text

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@
 - [Component Routing](#component-routing)
   - [Matching Patterns](#matching-patterns)
   - [Multiple Routers and URL Parameters](#multiple-routers-and-url-parameters)
-- [ROADMAP:](#roadmap)
+- [Roadmap](#roadmap)
 - [⭐ Give us a Star ⭐](https://github.com/dannyfranca/qwik-router)
 - [Contributing](#contributing)
 - [Code Of Conduct](#code-of-conduct)


### PR DESCRIPTION
# What is it?

  - [ ] Feature / enhancement
  - [ ] Bug
  - [x] Docs / tests / types / typos

# Description

Uses the same style as in the text.

# Use cases and why

Just to be consistent with all other list entries

# Checklist

  - [ ] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
  - [x] I have performed a self-review of my own code
  - [xI have made corresponding changes to the documentation
  - [x] Added new tests to cover the fix / functionality
